### PR TITLE
fix(disk health): don't warn when SMART is unavailable

### DIFF
--- a/roles/disk_health/README.md
+++ b/roles/disk_health/README.md
@@ -9,6 +9,9 @@ Every physical disk reported by `lsblk` is checked, excluding loop, zram, device
 - SATA temperature, power-on hours, wear, reallocated sectors, pending sectors, offline-uncorrectable sectors, and UDMA CRC errors;
 - NVMe temperature, available spare, spare threshold, percentage used, data units written, power-on hours, unsafe shutdowns, and media/data-integrity errors.
 
+A device that exposes no SMART data at all -- a USB flash drive behind a bridge with no SAT passthrough, for example -- is still listed, with a health of `SMART not available`, but does not raise a warning and
+is skipped for self-tests. Only a disk that reports a health verdict and fails it, or that trips a metric threshold, counts toward the warning total that sets the `OK`/`WARNING` subject line.
+
 Prometheus SMART collection belongs to the `telemetry_agent` role's upstream `smartctl_exporter`. This role remains responsible for the human-readable report and scheduled self-tests, avoiding a second
 implementation of SMART metric parsing.
 

--- a/roles/disk_health/files/disk_health.py
+++ b/roles/disk_health/files/disk_health.py
@@ -14,7 +14,7 @@ import subprocess
 import sys
 from typing import Dict, List, Optional, Sequence
 
-VERSION = "1.1.0"
+VERSION = "1.1.1"
 _LOGGER = logging.getLogger("disk_health")
 _DEFAULT_LOG_FILE = "/var/log/disk_health.log"
 _MAIL_FORWARD_CANDIDATES = (
@@ -298,7 +298,11 @@ def inspect_disk(disk: Disk) -> DiskReport:
     health = _parse_health(output)
     self_test = _run(["smartctl", "-l", "selftest", disk.path])
     warnings = _metric_warnings(protocol, metrics)
-    if health.upper() not in ("PASSED", "OK"):
+    # A device that exposes no SMART at all -- USB flash drives behind a bridge
+    # with no SAT passthrough, for instance -- is not a failing device, so it
+    # must not warn. Only a drive that reports a health verdict *and* fails it
+    # does. The report still lists the disk with "SMART not available".
+    if _smart_available(health) and health.upper() not in ("PASSED", "OK"):
         warnings.append(f"Overall SMART health: {health}")
     # smartctl uses bits 3-7 for failing health, prefail/past-threshold
     # attributes, error-log entries, and self-test errors.

--- a/roles/disk_health/tests/disk_health_test.py
+++ b/roles/disk_health/tests/disk_health_test.py
@@ -93,6 +93,52 @@ Media and Data Integrity Errors:   2
         )
         self.assertIn("Completed without error", latest)
 
+    def test_disk_without_smart_does_not_warn(self) -> None:
+        # A USB flash drive behind a bridge smartctl cannot talk SAT to. It
+        # reports no health verdict, which is not a fault -- it must not push
+        # the whole report into WARNING.
+        output = (
+            "/dev/sde: Unknown USB bridge [0x154b:0x1007 (0x110)]\n"
+            "Please specify device type with the -d option.\n"
+        )
+        report = self._inspect_with_smartctl_output(
+            disk_health.Disk(path="/dev/sde", model="USB 3.2.2 FD", size_bytes=500),
+            output,
+            returncode=1,
+        )
+        self.assertEqual(report.health, "SMART not available")
+        self.assertEqual(report.warnings, [])
+
+    def test_failing_smart_health_still_warns(self) -> None:
+        report = self._inspect_with_smartctl_output(
+            disk_health.Disk(path="/dev/sda", model="Dying SSD", size_bytes=500),
+            "SMART overall-health self-assessment test result: FAILED!\n",
+            returncode=0,
+        )
+        self.assertEqual(report.warnings, ["Overall SMART health: FAILED!"])
+
+    def _inspect_with_smartctl_output(
+        self,
+        disk: "disk_health.Disk",
+        output: str,
+        returncode: int,
+    ) -> "disk_health.DiskReport":
+        original_run = getattr(disk_health, "_run")
+        setattr(
+            disk_health,
+            "_run",
+            lambda _command: subprocess.CompletedProcess(
+                [],
+                returncode,
+                stdout=output,
+                stderr="",
+            ),
+        )
+        try:
+            return disk_health.inspect_disk(disk)
+        finally:
+            setattr(disk_health, "_run", original_run)
+
     def test_virtual_zvols_are_not_physical_disks(self) -> None:
         devices = {
             "blockdevices": [


### PR DESCRIPTION
## Problem

The nightly report on `watt` has been arriving as `[Disk Health] WARNING` with `warnings: 2` while nothing is actually wrong. Both warnings come from the two USB flash drives:

```
/dev/sde | 465.8 GiB | USB 3.2.2 FD | SATA
  Health: SMART not available
  WARNINGS:
    - Overall SMART health: SMART not available
```

`_parse_health()` returns the literal string `"SMART not available"` when smartctl reports no health line, and the overall-health check in `inspect_disk()` treated every non-`PASSED`/`OK` string as a fault. A device with no SMART is not a failing device, so the sentinel was being counted as one, and `run()` sums the warnings to pick the `OK`/`WARNING` subject line.

Confirmed on the host that these drives genuinely expose no SMART — this is not something a `-d` flag fixes:

```
/dev/sde: Unknown USB bridge [0x154b:0x1007 (0x110)]            # exit 1
/dev/sdf -d sat: Read Device Identity failed: unsupported scsi opcode   # exit 2
```

## Change

Gate the warning on the existing `_smart_available()` helper, which already draws exactly this distinction for the self-test scheduler — it just wasn't consulted on the warning path:

```python
if _smart_available(health) and health.upper() not in ("PASSED", "OK"):
    warnings.append(f"Overall SMART health: {health}")
```

Such disks are still listed in the report with `Health: SMART not available`; they simply no longer warn. A drive that reports a verdict and fails it still warns, as does any metric threshold trip.

`VERSION` bumped 1.1.0 → 1.1.1, and the README documents the behaviour.

## Tests

Two tests around a shared stub: one feeds the real `Unknown USB bridge` output from `watt` and asserts zero warnings, the paired one feeds `FAILED!` and asserts the warning still fires — so the fix can't silently swallow a genuinely failing drive. All 8 tests in the role pass.

## Verification on watt

Ran the patched script on the host with `--no-email --no-self-tests` against a scratch log (temp copy since removed; the deployed script was untouched):

```
Disks: 8; warnings: 0
/dev/sde | 465.8 GiB | USB 3.2.2 FD | SATA
  Health: SMART not available
  Indicators: OK
```

All eight disks still enumerated, the six real drives still `PASSED`, and the log lines drop from `[WARNING]` to `[INFO]`.

## Note on the base branch

This targets `vfio_and_style` rather than `main` because it builds on `_smart_available()`, which is introduced by 75a7e34 in #37 and does not exist on `main` yet. It should merge into #37 first, then reach `main` with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
