### PR TITLE
docs(vfio): record why the rescan list stays narrow

### DIFF
--- a/roles/vfio_rescan_hook/defaults/main.yml
+++ b/roles/vfio_rescan_hook/defaults/main.yml
@@ -18,6 +18,17 @@ vfio_rescan_hook_name: vfio-rescan
 # restart untouched, while the SAS2008 and the Arc do not. Blast radius should
 # match the demonstrated problem.
 #
+# That is measured, not assumed. Re-confirmed 2026-08-11 on the klaus-homelab
+# nas stage 3a rebuild: the guest was destroyed and rebuilt, then put through a
+# force `qm stop`/`qm start` AND a full host reboot. Both Optanes came back
+# present and usable every time while this list left them alone.
+#
+# Resist widening it to "everything passed through". Combined with
+# vfio_rescan_hook_fail_closed below, adding a device that does not need
+# re-enumeration converts a hypothetical rescan failure into a guest that will
+# not start at all — which is strictly worse than the problem it imagines it is
+# solving.
+#
 # Example on `watt` (SAS2008 + Arc A310 + its audio function):
 #   vfio_rescan_hook_pci_ids: ["1000:0072", "8086:56a6", "8086:4f92"]
 vfio_rescan_hook_pci_ids: []


### PR DESCRIPTION
Comments only — no behaviour change.

`vfio_rescan_hook_pci_ids` deliberately lists only the devices that actually wedge on a guest restart, but the defaults asserted that without recording where the conclusion came from or what happens if someone widens it. Two things added to the comment block:

**Where the scope came from.** Re-confirmed 2026-08-11 on the klaus-homelab `nas` stage 3a rebuild: the guest was destroyed and rebuilt, then put through a force `qm stop`/`qm start` and a full host reboot. Both Optanes came back present and usable every time while the list left them alone — so the narrow scope is measured, not assumed.

**Why widening it is a downgrade.** Combined with `vfio_rescan_hook_fail_closed`, adding a device that does not need re-enumeration converts a hypothetical rescan failure into a guest that will not start at all. On the mirrored Optane pair that is the whole pool's special vdev, that trades a demonstrated non-problem for a new start-path outage.

`inventory/hosts.yaml` already carries this reasoning for `watt` specifically; this puts it next to the variable itself, where someone editing the default will actually see it.

## Base branch

Targets `main` directly — `roles/vfio_rescan_hook/` is identical between `main` and `vfio_and_style`, so this has no dependency on #37 or #38 and can merge on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
